### PR TITLE
nonroot-documentation

### DIFF
--- a/documentation/docker/Dockerfile
+++ b/documentation/docker/Dockerfile
@@ -1,23 +1,40 @@
+# Stage 1: Kopi af YAML-filer fra oldDoc image
 FROM kvalitetsit/medcom-video-api-documentation:latest AS oldDoc
 COPY /maven/*.yaml /usr/share/nginx/html/
 
+# Stage 2: Endeligt image med Swagger UI
 FROM swaggerapi/swagger-ui:v3.27.0
 
+# Definer bruger- og gruppe-id
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+# Opret non-root gruppe og bruger med specifikke id'er
+RUN addgroup -g ${GROUP_ID} appgroup && \
+    adduser -u ${USER_ID} -G appgroup -S appuser
+
+# Kopier YAML-filer fra oldDoc stage
 COPY --from=oldDoc /usr/share/nginx/html/*.yaml /usr/share/nginx/html/
+
+# Kopier konfigurationsfiler og scripts
 COPY /versions /kit/versions
 COPY /config/setVersion.sh /kit/setVersion.sh
 COPY /config/setServers.sh /kit/setServers.sh
 COPY /config/config.sh /config.sh
-
 COPY /maven/runningVersion.json /kit/runningVersion.json
 
+# Installer nødvendige værktøjer og giv nødvendige tilladelser
 RUN apk update && \
     apk add jq && \
-#    apk add nano && \
     wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64" && \
     chmod +x /usr/bin/yq && \
     chmod +x /kit/setVersion.sh && \
     chmod +x /kit/setServers.sh && \
-    chmod +x /config.sh
+    chmod +x /config.sh && \
+    chown -R ${USER_ID}:${GROUP_ID} /kit /usr/share/nginx/html
 
+# Skift til non-root bruger med specifikke id'er
+USER ${USER_ID}:${GROUP_ID}
+
+# Start container med config.sh scriptet
 CMD ["sh", "/config.sh"]

--- a/documentation/docker/compose/docker-compose.yml
+++ b/documentation/docker/compose/docker-compose.yml
@@ -74,6 +74,7 @@ services:
        condition: service_healthy
    documentation-and-test:
      image: kvalitetsit/medcom-video-api-documentation:latest
+     user: "1000:1000"
      environment:
       - BASE_URL=/test
      ports:


### PR DESCRIPTION
Netic requires documentation to be run nonroot.

Jeg fik en fejl med permission denied når containeren kørte nonroot, og den forsøgte at oprette filer inde i /kit. Jeg prøvede at mounte /kit ind, men så er script'sne væk.. 
Følgende PR er blevet reverted efter findingen; https://github.com/KvalitetsIT/kitcaddy/pull/44

Løsningen er at fikse documentation-dockerfilen alle steder - Min plan er at starte her i videoapi'et, også når den virker, få det ud alle andre steder




**Jeg har lavet 2 commits;** 
- Første commit er for at fremprovokere den samme fejl, som jeg får på miljøet
- Andet commit er for at fikse den fremprovokerede fejl

## Lokal-test:
### Efter første commit:
![image](https://github.com/user-attachments/assets/90744a35-a240-4250-b83c-455eec95fae4)

(Samme fejl som på miljøet)
```
docker compose up documentation-and-test
[+] Running 1/0
 ✔ Container compose-documentation-and-test-1  Created                                                                                                                                                                                                                                                           0.0s 
Attaching to documentation-and-test-1
documentation-and-test-1  | Running set version
documentation-and-test-1  | Add Dev version to list of versions
documentation-and-test-1  | /kit/setVersion.sh: line 15: can't create /kit/env: Permission denied
documentation-and-test-1  | Is dev version
documentation-and-test-1  | /kit/setVersion.sh: line 24: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | Creating file with version and path
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory
documentation-and-test-1  | /kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
documentation-and-test-1  | cat: can't open '/kit/env': No such file or directory
documentation-and-test-1  | mv: can't rename '/kit/env.tmp': No such file or directory

```
### Efter andet commit:
![image](https://github.com/user-attachments/assets/a25caa07-16a8-4f27-baf6-cdfbc07d71b3)

```
 docker compose up documentation-and-test
[+] Running 1/0
 ✔ Container compose-documentation-and-test-1  Recreated                                                                                                                                                                                                                                                         0.1s 
Attaching to documentation-and-test-1
documentation-and-test-1  | Running set version
documentation-and-test-1  | Add Dev version to list of versions
documentation-and-test-1  | Is dev version
documentation-and-test-1  | Creating file with version and path
documentation-and-test-1  | Updates version in doc file
documentation-and-test-1  | Running set servers
documentation-and-test-1  | SERVER_URLS NOT set
documentation-and-test-1  | Sets env URLS to list of versions
documentation-and-test-1  | Restarting nginx
documentation-and-test-1  | 192.168.96.1 - - [31/Oct/2024:10:42:53 +0000] "GET /test HTTP/1.1" 301 169 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
documentation-and-test-1  | 192.168.96.1 - - [31/Oct/2024:10:42:53 +0000] "GET /test/ HTTP/1.1" 200 801 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
documentation-and-test-1  | 192.168.96.1 - - [31/Oct/2024:10:42:53 +0000] "GET /test/swagger-ui.css HTTP/1.1" 200 22006 "http://localhost/test/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
documentation-and-test-1  | 192.168.96.1 - - [31/Oct/2024:10:42:53 +0000] "GET /test/swagger-ui-standalone-preset.js HTTP/1.1" 200 96735 "http://localhost/test/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
documentation-and-test-1  | 192.168.96.1 - - [31/Oct/2024:10:42:53 +0000] "GET /test/swagger-ui-bundle.js HTTP/1.1" 200 295131 "http://localhost/test/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
documentation-and-test-1  | 192.168.96.1 - - [31/Oct/2024:10:42:54 +0000] "GET /test/.yaml HTTP/1.1" 200 72731 "http://localhost/test/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"

```