### PR TITLE
Updated Maven coordinates for Logback Access

### DIFF
--- a/medcom-video-api-web/pom.xml
+++ b/medcom-video-api-web/pom.xml
@@ -26,9 +26,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-access</artifactId>
-			<version>1.5.16</version>
+			<groupId>ch.qos.logback.access</groupId>
+			<artifactId>common</artifactId>
+			<version>2.0.1</version>
 			<scope>runtime</scope>
 		</dependency>
 


### PR DESCRIPTION
Changed the Maven path for Logback access. This was done because of warnings from Maven about the used of the old coordinates.