### PR TITLE
Aftaleservice v3

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -157,6 +157,7 @@
                                 <useSpringBoot3>true</useSpringBoot3>
                                 <useJakartaEe>true</useJakartaEe>
                                 <containerDefaultToNull>true</containerDefaultToNull>
+                                <useSealed>true</useSealed>
                             </configOptions>
                             <output>${project.build.directory}/generated-test-sources/openapi/test</output>
                             <generateApiTests>false</generateApiTests>
@@ -183,6 +184,7 @@
                                 <useJakartaEe>true</useJakartaEe>
                                 <useTags>true</useTags>
                                 <containerDefaultToNull>true</containerDefaultToNull>
+                                <useSealed>true</useSealed>
                             </configOptions>
                             <output>${project.build.directory}/generated-sources/openapi/main</output>
                             <generateApiDocumentation>false</generateApiDocumentation>
@@ -204,6 +206,7 @@
                                 <useSpringBoot3>true</useSpringBoot3>
                                 <useJakartaEe>true</useJakartaEe>
                                 <containerDefaultToNull>true</containerDefaultToNull>
+                                <useSealed>true</useSealed>
                             </configOptions>
                             <output>${project.build.directory}/generated-test-sources/openapi/test</output>
                             <generateApiTests>false</generateApiTests>
@@ -230,6 +233,7 @@
                                 <useJakartaEe>true</useJakartaEe>
                                 <useTags>true</useTags>
                                 <containerDefaultToNull>true</containerDefaultToNull>
+                                <useSealed>true</useSealed>
                             </configOptions>
                             <output>${project.build.directory}/generated-sources/openapi/main</output>
                             <generateApiDocumentation>false</generateApiDocumentation>

--- a/documentation/src/main/resources/video-api-v2.yaml
+++ b/documentation/src/main/resources/video-api-v2.yaml
@@ -146,6 +146,40 @@ tags:
 servers:
   - url: 'http://localhost:8081'
 paths:
+  /v3/meetings:
+    get:
+      security:
+        - keycloakOIDC: [ ]
+      tags:
+        - Video Meetings V3
+      summary: gets a list of meetings
+      description: "TBD"
+      parameters:
+        - name: type
+          in: query
+          description: filters the meeting to a certain type
+          required: false
+          schema:
+            type: string
+          example: 'simpleMeeting'
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/hal+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/meeting'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '500':
+          $ref: '#/components/responses/500'
+
   /v2/info:
     get:
       security:
@@ -204,7 +238,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meeting'
+                $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -243,7 +277,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meeting'
+                $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -349,7 +383,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/meeting'
+                  $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -389,7 +423,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meeting'
+                $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -424,7 +458,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meeting'
+                $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -464,7 +498,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meeting'
+                $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -506,7 +540,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meeting'
+                $ref: '#/components/schemas/detailedMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -1133,7 +1167,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/meetingParticipantResponse'
+                  $ref: '#/components/schemas/Participant'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -1163,7 +1197,7 @@ paths:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/meetingParticipantRequest'
+                $ref: '#/components/schemas/Participant'
       responses:
         '200':
           description: Ok
@@ -1172,7 +1206,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/meetingParticipantResponse'
+                  $ref: '#/components/schemas/Participant'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -1202,14 +1236,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/meetingParticipantRequest'
+              $ref: '#/components/schemas/Participant'
       responses:
         '200':
           description: Ok
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/meetingParticipantResponse'
+                $ref: '#/components/schemas/Participant'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -1270,7 +1304,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/meetingSimpleResponse'
+                  $ref: '#/components/schemas/simpleMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -1295,7 +1329,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/citizenParticipantRequest'
+              $ref: '#/components/schemas/CitizenParticipant'
       responses:
         '200':
           description: Ok
@@ -1304,7 +1338,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/meetingSimpleResponse'
+                  $ref: '#/components/schemas/simpleMeeting'
         '400':
           $ref: '#/components/responses/400'
         '401':
@@ -1457,6 +1491,20 @@ components:
     meeting:
       type: object
       required:
+        - type
+      description: "TBD"
+      oneOf:
+        - $ref: '#/components/schemas/detailedMeeting'
+        - $ref: '#/components/schemas/simpleMeeting'
+      discriminator:
+        propertyName: type
+        mapping:
+          detailedMeeting: '#/components/schemas/detailedMeeting'
+          simpleMeeting: '#/components/schemas/simpleMeeting'
+
+    detailedMeeting:
+      type: object
+      required:
         - subject
         - uuid
         - createdBy
@@ -1466,6 +1514,10 @@ components:
         - _links
         - shortId
       properties:
+        type:
+          type: string
+          description: "Identifies the variant of meeting"
+          example: "detailedMeeting"
         subject:
           type: string
           maxLength: 100
@@ -1686,7 +1738,7 @@ components:
         meetingParticipants:
           type: array
           items:
-            $ref: '#/components/schemas/meetingParticipantRequest'
+            $ref: '#/components/schemas/Participant'
 
     update-meeting:
       type: object
@@ -1734,7 +1786,7 @@ components:
         meetingParticipants:
           type: array
           items:
-            $ref: '#/components/schemas/meetingParticipantRequest'
+            $ref: '#/components/schemas/Participant'
 
     patch-meeting:
       type: object
@@ -1792,7 +1844,7 @@ components:
         meetingParticipants:
           type: array
           items:
-            $ref: '#/components/schemas/meetingParticipantRequest'
+            $ref: '#/components/schemas/Participant'
 
     scheduling-info:
       type: object
@@ -1921,7 +1973,7 @@ components:
           maxLength: 200
           description: If set this is the url that the portal should redirect the user to when the meeting ends.
         meetingDetails:
-          $ref: '#/components/schemas/meeting'
+          $ref: '#/components/schemas/detailedMeeting'
         _links:
           properties:
             self:
@@ -2366,8 +2418,21 @@ components:
           items:
             $ref: '#/components/schemas/scheduling-info'
 
-    meetingParticipantRequest:
+    Participant:
       type: object
+      description: "TBD"
+      oneOf:
+        - $ref: '#/components/schemas/OrganisationParticipant'
+        - $ref: '#/components/schemas/UserParticipant'
+        - $ref: '#/components/schemas/DeviceParticipant'
+        - $ref: '#/components/schemas/CitizenParticipant'
+      discriminator:
+        propertyName: type
+        mapping:
+          OrganisationParticipant: '#/components/schemas/OrganisationParticipant'
+          UserParticipant: '#/components/schemas/UserParticipant'
+          DeviceParticipant: '#/components/schemas/DeviceParticipant'
+          CitizenParticipant: '#/components/schemas/CitizenParticipant'
       properties:
         role:
           description: Role of participant
@@ -2376,47 +2441,8 @@ components:
             - host
             - guest
           default: guest
-        participantType:
-          description: Kind of participant
-          type: string
-          enum:
-            - organisation
-            - user
-            - device
-            - citizen
-        participantId:
-          oneOf:
-            - $ref: '#/components/schemas/organisationParticipant'
-            - $ref: '#/components/schemas/userParticipant'
-            - $ref: '#/components/schemas/deviceParticipant'
-            - $ref: '#/components/schemas/citizenParticipantRequest'
 
-    meetingParticipantResponse:
-      type: object
-      properties:
-        role:
-          description: Role of participant
-          type: string
-          enum:
-            - host
-            - guest
-          default: guest
-        participantType:
-          description: Kind of participant
-          type: string
-          enum:
-            - organisation
-            - user
-            - device
-            - citizen
-        participantId:
-          oneOf:
-            - $ref: '#/components/schemas/organisationParticipant'
-            - $ref: '#/components/schemas/userParticipant'
-            - $ref: '#/components/schemas/deviceParticipant'
-            - $ref: '#/components/schemas/citizenParticipantResponse'
-
-    organisationParticipant:
+    OrganisationParticipant:
       type: object
       required:
         - organisationId
@@ -2425,35 +2451,45 @@ components:
           description: Organisation id
           type: string
           # TODO overvej om det skal være et uuid (udvidelse af org service)
+        type:
+          type: string
+          description: "Identifies the variant of participant"
+          example: "OrganisationParticipant"
 
-    userParticipant:
-      type: object
-      required:
-        - organisationId
-        - email
-      properties:
-        organisationId:
-          description: Organisation id of user
-          type: string
-        email:
-          description: Email of user
-          type: string
+    UserParticipant:
+      allOf:
+        - $ref: "#/components/schemas/OrganisationParticipant"
+        - type: object
+          required:
+            - organisationId
+            - email
+          properties:
+            email:
+              description: Email of user
+              type: string
+            type:
+              type: string
+              description: "Identifies the variant of participant"
+              example: "UserParticipant"
 
-    deviceParticipant:
-      type: object
-      required:
-        - organisationId
-        - deviceId
-      properties:
-        organisationId:
-          description: Organisation id of device
-          type: string
-        deviceId:
-          description: Uuid of device
-          type: string
-          format: uuid
+    DeviceParticipant:
+      allOf:
+        - $ref: "#/components/schemas/OrganisationParticipant"
+        - type: object
+          required:
+            - organisationId
+            - deviceId
+          properties:
+            deviceId:
+              description: Uuid of device
+              type: string
+              format: uuid
+            type:
+              type: string
+              description: "Identifies the variant of participant"
+              example: "DeviceParticipant"
 
-    citizenParticipantRequest:
+    CitizenParticipant:
       type: object
       required:
         - cprId
@@ -2461,13 +2497,19 @@ components:
         cprId:
           description: Encrypted cpr of citizen, only for requests, never for responses
           type: string
+        type:
+          type: string
+          description: "Identifies the variant of participant"
+          example: "CitizenParticipant"
 
-    citizenParticipantResponse:
-      type: object
 
-    meetingSimpleResponse:
+    simpleMeeting:
       type: object
       properties:
+        type:
+          type: string
+          description: "Identifies the variant of meeting"
+          example: "simpleMeeting"
         pin:
           description: Host or guest pin of meeting, should match if user is host or guest
           type: integer

--- a/integrationtest/src/test/java/dk/medcom/video/api/integrationtest/v2/VideoMeetingsIT.java
+++ b/integrationtest/src/test/java/dk/medcom/video/api/integrationtest/v2/VideoMeetingsIT.java
@@ -1389,7 +1389,7 @@ class VideoMeetingsIT extends AbstractIntegrationTest {
         return random.nextBoolean();
     }
 
-    private void testLinks(UUID meetingUuid, MeetingLinks links) {
+    private void testLinks(UUID meetingUuid, DetailedMeetingLinks links) {
         assertNotNull(links);
         assertNotNull(links.getSelf());
         assertNotNull(links.getSelf().getHref());

--- a/integrationtest/src/test/java/dk/medcom/video/api/integrationtest/v2/VideoSchedulingInformationIT.java
+++ b/integrationtest/src/test/java/dk/medcom/video/api/integrationtest/v2/VideoSchedulingInformationIT.java
@@ -1167,7 +1167,7 @@ class VideoSchedulingInformationIT extends AbstractIntegrationTest {
         return UUID.randomUUID().toString();
     }
 
-    private void testMeetingLinks(UUID meetingUuid, MeetingLinks links) {
+    private void testMeetingLinks(UUID meetingUuid, DetailedMeetingLinks links) {
         assertNotNull(links);
         assertNotNull(links.getSelf());
         assertNotNull(links.getSelf().getHref());

--- a/medcom-video-api-service/src/main/java/dk/medcom/video/api/controller/v2/ParticipantController.java
+++ b/medcom-video-api-service/src/main/java/dk/medcom/video/api/controller/v2/ParticipantController.java
@@ -1,0 +1,41 @@
+package dk.medcom.video.api.controller.v2;
+
+import jakarta.validation.Valid;
+import org.openapitools.api.ParticipantsApi;
+import org.openapitools.model.*;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+public class ParticipantController  implements ParticipantsApi  {
+    @Override
+    public ResponseEntity<List<SimpleMeeting>> v2MeetingDetailsGet(String participantOrganisation) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<List<SimpleMeeting>> v2MeetingDetailsPost(CitizenParticipant citizenParticipant) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<List<Participant>> v2MeetingsUuidParticipantsGet(UUID uuid) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<Void> v2MeetingsUuidParticipantsIdDelete(UUID uuid, Long id) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<Participant> v2MeetingsUuidParticipantsIdPut(UUID uuid, Long id, Participant participant) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<List<Participant>> v2MeetingsUuidParticipantsPost(UUID uuid, List<@Valid Participant> participant) {
+        return null;
+    }
+}

--- a/medcom-video-api-service/src/main/java/dk/medcom/video/api/controller/v2/VideoMeetingsControllerV2.java
+++ b/medcom-video-api-service/src/main/java/dk/medcom/video/api/controller/v2/VideoMeetingsControllerV2.java
@@ -40,7 +40,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(anyRoleAtt)
-    public ResponseEntity<Meeting> v2MeetingsFindByUriWithDomainGet(String uri) {
+    public ResponseEntity<DetailedMeeting> v2MeetingsFindByUriWithDomainGet(String uri) {
         logger.debug("Enter GET meetings by uri with domain: {}, v2.", uri);
         try {
             var meetings = meetingService.getMeetingsByUriWithDomainSingleV2(uri);
@@ -58,7 +58,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(anyRoleAtt)
-    public ResponseEntity<Meeting> v2MeetingsFindByUriWithoutDomainGet(String uri) {
+    public ResponseEntity<DetailedMeeting> v2MeetingsFindByUriWithoutDomainGet(String uri) {
         logger.debug("Enter GET meetings by uri without domain: {}, v2.", uri);
         try {
             var meetings = meetingService.getMeetingsByUriWithoutDomainV2(uri);
@@ -76,7 +76,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(anyRoleAtt)
-    public ResponseEntity<List<Meeting>> v2MeetingsGet(OffsetDateTime fromStartTime, OffsetDateTime toStartTime, String shortId, String subject, String organizedBy, String search, String label, String uriWithDomain) {
+    public ResponseEntity<List<DetailedMeeting>> v2MeetingsGet(OffsetDateTime fromStartTime, OffsetDateTime toStartTime, String shortId, String subject, String organizedBy, String search, String label, String uriWithDomain) {
         logger.debug("Enter GET meetings, v2.");
         try {
             if (shortId != null && !shortId.isEmpty()) {
@@ -109,7 +109,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
         }
     }
 
-    private ResponseEntity<List<Meeting>> meetingsGet(OffsetDateTime fromStartTime, OffsetDateTime toStartTime) {
+    private ResponseEntity<List<DetailedMeeting>> meetingsGet(OffsetDateTime fromStartTime, OffsetDateTime toStartTime) {
         logger.debug("Get meetings by fromStartTime: {} toStartTime: {}, v2.", fromStartTime.toString(), toStartTime.toString());
 
         List<MeetingModel> meetings = meetingService.getMeetingsV2(fromStartTime, toStartTime);
@@ -117,7 +117,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
         return ResponseEntity.ok(VideoMeetingMapper.internalToExternal(meetings));
     }
 
-    private ResponseEntity<List<Meeting>> genericSearchMeetings(String search, OffsetDateTime fromStartTime, OffsetDateTime toStartTime) {
+    private ResponseEntity<List<DetailedMeeting>> genericSearchMeetings(String search, OffsetDateTime fromStartTime, OffsetDateTime toStartTime) {
         logger.debug("Get meetings by search: {}, fromStartTime: {}, toStartTime: {}, v2.", search, fromStartTime, toStartTime);
 
         if((fromStartTime != null && toStartTime == null) || (fromStartTime == null && toStartTime != null)) {
@@ -132,31 +132,31 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
         return ResponseEntity.ok(VideoMeetingMapper.internalToExternal(meetings));
     }
 
-    private ResponseEntity<List<Meeting>> getMeetingsByLabel(String label) {
+    private ResponseEntity<List<DetailedMeeting>> getMeetingsByLabel(String label) {
         logger.debug("Get meetings by label: {}, v2.", label);
         var meetings = meetingService.getMeetingsByLabelV2(label);
         return ResponseEntity.ok(VideoMeetingMapper.internalToExternal(meetings));
     }
 
-    private ResponseEntity<List<Meeting>> getMeetingByShortId(String shortId) {
+    private ResponseEntity<List<DetailedMeeting>> getMeetingByShortId(String shortId) {
         logger.debug("Get meetings by shortId: {}, v2.", shortId);
         var meeting = meetingService.getMeetingByShortIdV2(shortId);
         return ResponseEntity.ok(List.of(VideoMeetingMapper.internalToExternal(meeting)));
     }
 
-    private ResponseEntity<List<Meeting>> getMeetingsBySubject(String subject) {
+    private ResponseEntity<List<DetailedMeeting>> getMeetingsBySubject(String subject) {
         logger.debug("Get meetings by subject: {}, v2.", subject);
         var meetings = meetingService.getMeetingsBySubjectV2(subject);
         return ResponseEntity.ok(VideoMeetingMapper.internalToExternal(meetings));
     }
 
-    private ResponseEntity<List<Meeting>> getMeetingsOrganizedBy(String organizedBy) {
+    private ResponseEntity<List<DetailedMeeting>> getMeetingsOrganizedBy(String organizedBy) {
         logger.debug("Get meetings by organized by: {}, v2.", organizedBy);
         var meetings = meetingService.getMeetingsByOrganizedByV2(organizedBy);
         return ResponseEntity.ok(VideoMeetingMapper.internalToExternal(meetings));
     }
 
-    private ResponseEntity<List<Meeting>> getMeetingsFindByUriWithDomainGet(String uri) {
+    private ResponseEntity<List<DetailedMeeting>> getMeetingsFindByUriWithDomainGet(String uri) {
         logger.debug("Get meetings by uri with domain: {}, v2.", uri);
         var meetings = meetingService.getMeetingsByUriWithDomainV2(uri);
         return ResponseEntity.ok(VideoMeetingMapper.internalToExternal(meetings));
@@ -165,7 +165,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(plannerProvisionerUserAdminUserRoleAtt)
-    public ResponseEntity<Meeting> v2MeetingsPost(CreateMeeting createMeeting) {
+    public ResponseEntity<DetailedMeeting> v2MeetingsPost(CreateMeeting createMeeting) {
         logger.debug("Enter POST meetings, v2.");
 
         var performanceLogger = new PerformanceLogger("create meeting");
@@ -214,7 +214,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(anyRoleAtt)
-    public ResponseEntity<Meeting> v2MeetingsUuidGet(UUID uuid) {
+    public ResponseEntity<DetailedMeeting> v2MeetingsUuidGet(UUID uuid) {
         logger.debug("Enter GET meetings with uuid: {}, v2.", uuid);
         try {
             var meeting = meetingService.getMeetingByUuidV2(uuid);
@@ -232,7 +232,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(plannerProvisionerUserAdminUserRoleAtt)
-    public ResponseEntity<Meeting> v2MeetingsUuidPatch(UUID uuid, PatchMeeting patchMeeting) {
+    public ResponseEntity<DetailedMeeting> v2MeetingsUuidPatch(UUID uuid, PatchMeeting patchMeeting) {
         logger.debug("Enter PATCH meetings with uuid: {}, v2.", uuid);
         try {
             var meeting = meetingService.patchMeetingV2(uuid, VideoMeetingMapper.externalToInternal(patchMeeting));
@@ -255,7 +255,7 @@ public class VideoMeetingsControllerV2 implements VideoMeetingsV2Api {
     @Oauth
     @Override
     @PreAuthorize(plannerProvisionerUserAdminUserRoleAtt)
-    public ResponseEntity<Meeting> v2MeetingsUuidPut(UUID uuid, UpdateMeeting updateMeeting) {
+    public ResponseEntity<DetailedMeeting> v2MeetingsUuidPut(UUID uuid, UpdateMeeting updateMeeting) {
         logger.debug("Enter PUT meetings with uuid: {}, v2.", uuid);
         try {
             var meeting = meetingService.updateMeetingV2(uuid, VideoMeetingMapper.externalToInternal(updateMeeting));

--- a/medcom-video-api-service/src/main/java/dk/medcom/video/api/controller/v2/mapper/VideoMeetingMapper.java
+++ b/medcom-video-api-service/src/main/java/dk/medcom/video/api/controller/v2/mapper/VideoMeetingMapper.java
@@ -10,22 +10,22 @@ import java.util.List;
 
 public class VideoMeetingMapper {
 
-    public static List<Meeting> internalToExternal(List<MeetingModel> input) {
+    public static List<DetailedMeeting> internalToExternal(List<MeetingModel> input) {
         return input.stream().map(VideoMeetingMapper::internalToExternal).toList();
     }
 
-    public static Meeting internalToExternal(MeetingModel input) {
+    public static DetailedMeeting internalToExternal(MeetingModel input) {
         if (input == null) {
             return null;
         }
 
         var selfLink = MvcUriComponentsBuilder.fromMethodCall(MvcUriComponentsBuilder.on(VideoMeetingsControllerV2.class).v2MeetingsUuidGet(input.uuid())).scheme("https").build().toUri();
-        var meetingLinksSelf = new MeetingLinksSelf().href(selfLink);
+        var meetingLinksSelf = new DetailedMeetingLinksSelf().href(selfLink);
 
         var schedulingInfoLink = MvcUriComponentsBuilder.fromMethodCall(MvcUriComponentsBuilder.on(VideoSchedulingInformationControllerV2.class).v2SchedulingInfoUuidGet(input.uuid())).scheme("https").build().toUri();
-        var meetingLinksSchedulingInfo = new MeetingLinksSchedulingInfo().href(schedulingInfoLink);
+        var meetingLinksSchedulingInfo = new DetailedMeetingLinksSchedulingInfo().href(schedulingInfoLink);
 
-        return new Meeting()
+        return new DetailedMeeting()
                 .subject(input.subject())
                 .uuid(input.uuid())
                 .createdBy(internalToExternal(input.createdBy()))
@@ -45,7 +45,7 @@ public class VideoMeetingMapper {
                 .guestMicrophone(EnumMapper.internalToExternal(input.guestMicrophone()))
                 .guestPinRequired(input.guestPinRequired())
                 .additionalInformation(input.additionalInformation().stream().map(VideoMeetingMapper::internalToExternal).toList())
-                .links(new MeetingLinks().self(meetingLinksSelf).schedulingInfo(meetingLinksSchedulingInfo));
+                .links(new DetailedMeetingLinks().self(meetingLinksSelf).schedulingInfo(meetingLinksSchedulingInfo));
     }
 
     public static CreateMeetingModel externalToInternal(CreateMeeting input) {

--- a/medcom-video-api-service/src/test/java/dk/medcom/video/api/controller/v2/HelperMethods.java
+++ b/medcom-video-api-service/src/test/java/dk/medcom/video/api/controller/v2/HelperMethods.java
@@ -302,7 +302,7 @@ public class HelperMethods {
         assertEquals(expected.shortlink(), actual.getShortlink());
     }
 
-    public static void assertMeeting(MeetingModel expected, Meeting actual) {
+    public static void assertMeeting(MeetingModel expected, DetailedMeeting actual) {
         assertEquals(expected.subject(), actual.getSubject());
         assertEquals(expected.uuid(), actual.getUuid());
         assertMeetingUser(expected.createdBy(), actual.getCreatedBy());

--- a/medcom-video-api-test/src/test/java/dk/medcom/video/api/test/MeetingIT.java
+++ b/medcom-video-api-test/src/test/java/dk/medcom/video/api/test/MeetingIT.java
@@ -11,6 +11,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.api.InfoApi;
 import org.openapitools.client.api.VideoMeetingsApi;
+import org.openapitools.client.api.VideoMeetingsV2Api;
 import org.openapitools.client.api.VideoSchedulingInformationApi;
 import org.openapitools.client.model.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MeetingIT extends IntegrationWithOrganisationServiceTest {
-	private VideoMeetingsApi videoMeetings;
+	private VideoMeetingsV2Api videoMeetings;
 	private VideoSchedulingInformationApi schedulingInfoApi;
 	private InfoApi infoApi;
 
@@ -45,7 +46,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 				.setBasePath(String.format("http://%s:%s/api", videoApi.getHost(), videoApiPort))
 				.setOffsetDateTimeFormat(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss X"));
 
-		videoMeetings = new VideoMeetingsApi(apiClient);
+		videoMeetings = new VideoMeetingsV2Api(apiClient);
 
 		infoApi = new InfoApi(apiClient);
 
@@ -91,10 +92,10 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	@Test
 	public void testUriWithDomain() throws ApiException {
 		var createMeeting = createMeeting(UUID.randomUUID().toString());
-		var createdMeeting = videoMeetings.meetingsPost(createMeeting);
+		var createdMeeting = videoMeetings.v2MeetingsPost(createMeeting);
 		var schedulingInfo = schedulingInfoApi.schedulingInfoUuidGet(createdMeeting.getUuid());
 		// 1236@test.dk 1238
-		var result = videoMeetings.meetingsFindByUriWithDomainGet(schedulingInfo.getUriWithDomain());
+		var result = videoMeetings.v2MeetingsFindByUriWithDomainGet(schedulingInfo.getUriWithDomain());
 
 		assertNotNull(result);
 		assertEquals(createdMeeting.getUuid(), result.getUuid());
@@ -106,9 +107,9 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	@Test
 	public void testUriWithoutDomain() throws ApiException {
 		var createMeeting = createMeeting(UUID.randomUUID().toString());
-		var createdMeeting = videoMeetings.meetingsPost(createMeeting);
+		var createdMeeting = videoMeetings.v2MeetingsPost(createMeeting);
 		var schedulingInfo = schedulingInfoApi.schedulingInfoUuidGet(createdMeeting.getUuid());
-		var result = videoMeetings.meetingsFindByUriWithoutDomainGet(schedulingInfo.getUriWithoutDomain());
+		var result = videoMeetings.v2MeetingsFindByUriWithoutDomainGet(schedulingInfo.getUriWithoutDomain());
 
 		assertNotNull(result);
 		assertEquals(createdMeeting.getUuid(), result.getUuid());
@@ -118,7 +119,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	public void testCanCreatePoolMeeting() throws ApiException {
 		var createMeeting = createMeeting(UUID.randomUUID().toString());
 		createMeeting.meetingType(MeetingType.POOL);
-		var result = videoMeetings.meetingsPost(createMeeting);
+		var result = videoMeetings.v2MeetingsPost(createMeeting);
 
 		assertNotNull(result);
 	}
@@ -136,7 +137,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		createMeeting.getAdditionalInformation().add(createAdditionalInformationType("key one", "value one"));
 		createMeeting.getAdditionalInformation().add(createAdditionalInformationType("key two", "value two"));
 
-		var createdMeeting = videoMeetings.meetingsPost(createMeeting);
+		var createdMeeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(createdMeeting);
 		assertEquals(createMeeting.getExternalId(), createdMeeting.getExternalId());
 		assertEquals(2, createdMeeting.getLabels().size());
@@ -157,14 +158,14 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		updateMeeting.setLabels(new ArrayList<>());
 		updateMeeting.getLabels().add("Another Label");
 
-		var updatedMeeting = videoMeetings.meetingsUuidPut(createdMeeting.getUuid(), updateMeeting);
+		var updatedMeeting = videoMeetings.v2MeetingsUuidPut(createdMeeting.getUuid(), updateMeeting);
 		assertNotNull(updatedMeeting);
 		assertEquals(createMeeting.getExternalId(), updatedMeeting.getExternalId());
 		assertEquals(1, updatedMeeting.getLabels().size());
 		assertTrue(updateMeeting.getLabels().containsAll(updatedMeeting.getLabels()));
 		assertTrue(updatedMeeting.getAdditionalInformation().isEmpty());
 
-		var readMeeting = videoMeetings.meetingsUuidGet(createdMeeting.getUuid());
+		var readMeeting = videoMeetings.v2MeetingsUuidGet(createdMeeting.getUuid());
 		assertNotNull(readMeeting);
 		assertEquals(createMeeting.getExternalId(), readMeeting.getExternalId());
 		assertEquals(1, readMeeting.getLabels().size());
@@ -176,7 +177,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	public void testCanCreateExternalId() throws ApiException {
 		var createMeeting = createMeeting("another_external_id");
 
-		var meeting = videoMeetings.meetingsPost(createMeeting);
+		var meeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(meeting);
 		assertEquals(createMeeting.getExternalId(), meeting.getExternalId());
 	}
@@ -186,7 +187,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		var createMeeting = createMeeting("another_external_id3");
 		createMeeting.setGuestMicrophone(org.openapitools.client.model.GuestMicrophone.MUTED);
 
-		var meeting = videoMeetings.meetingsPost(createMeeting);
+		var meeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(meeting);
 		assertEquals(createMeeting.getExternalId(), meeting.getExternalId());
 		assertEquals(org.openapitools.client.model.GuestMicrophone.MUTED, meeting.getGuestMicrophone());
@@ -196,7 +197,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	public void testCanCreateWithMicNotSet() throws ApiException {
 		var createMeeting = createMeeting("another_external_id2");
 
-		var meeting = videoMeetings.meetingsPost(createMeeting);
+		var meeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(meeting);
 		assertEquals(createMeeting.getExternalId(), meeting.getExternalId());
 		assertEquals(org.openapitools.client.model.GuestMicrophone.ON, meeting.getGuestMicrophone());
@@ -206,7 +207,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	public void testCanCreateWithGuestPinRequiredNotSet() throws ApiException {
 		var createMeeting = createMeeting("another_external_id4");
 
-		var meeting = videoMeetings.meetingsPost(createMeeting);
+		var meeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(meeting);
 		assertEquals(createMeeting.getExternalId(), meeting.getExternalId());
 		assertFalse(meeting.getGuestPinRequired());
@@ -217,7 +218,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		var createMeeting = createMeeting("another_external_id5");
 		createMeeting.setGuestPinRequired(false);
 
-		var meeting = videoMeetings.meetingsPost(createMeeting);
+		var meeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(meeting);
 		assertEquals(createMeeting.getExternalId(), meeting.getExternalId());
 		assertFalse(meeting.getGuestPinRequired());
@@ -228,7 +229,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		var createMeeting = createMeeting("another_external_id6");
 		createMeeting.setGuestPinRequired(true);
 
-		var meeting = videoMeetings.meetingsPost(createMeeting);
+		var meeting = videoMeetings.v2MeetingsPost(createMeeting);
 		assertNotNull(meeting);
 		assertEquals(createMeeting.getExternalId(), meeting.getExternalId());
 		assertTrue(meeting.getGuestPinRequired());
@@ -239,7 +240,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		var createMeeting = createMeeting("external_id");
 
 		try {
-			videoMeetings.meetingsPost(createMeeting);
+			videoMeetings.v2MeetingsPost(createMeeting);
 			fail();
 		}
 		catch(ApiException e) {
@@ -357,13 +358,13 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		request.setDescription("SOME DESCRIPTION");
 		request.setGuestPinRequired(true);
 		request.setAdditionalInformation(List.of(createAdditionalInformationType("new key", "new value"), createAdditionalInformationType("another key", "another value")));
-		var response = videoMeetings.meetingsUuidPatch(UUID.fromString(createResponse.getUuid()), request);
+		var response = videoMeetings.v2MeetingsUuidPatch(UUID.fromString(createResponse.getUuid()), request);
 		var updatedSchedulingInfo = schedulingInfoApi.schedulingInfoUuidGet(UUID.fromString(createResponse.getUuid()));
 
 		// Then
 		assertNotNull(response);
 
-		var getResponse = videoMeetings.meetingsUuidGet(UUID.fromString(createResponse.getUuid()));
+		var getResponse = videoMeetings.v2MeetingsUuidGet(UUID.fromString(createResponse.getUuid()));
 
 		assertNotNull(getResponse);
 		assertNotEquals(createMeeting.getDescription(), getResponse.getDescription());
@@ -379,13 +380,13 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 		request = new PatchMeeting();
 		request.setHostPin(4321);
 		request.setGuestPin(1234);
-		response = videoMeetings.meetingsUuidPatch(UUID.fromString(createResponse.getUuid()), request);
+		response = videoMeetings.v2MeetingsUuidPatch(UUID.fromString(createResponse.getUuid()), request);
 
 		// Then
 		assertNotNull(response);
 		assertEquals(2, response.getAdditionalInformation().size());
 
-		getResponse = videoMeetings.meetingsUuidGet(UUID.fromString(createResponse.getUuid()));
+		getResponse = videoMeetings.v2MeetingsUuidGet(UUID.fromString(createResponse.getUuid()));
 		updatedSchedulingInfo = schedulingInfoApi.schedulingInfoUuidGet(UUID.fromString(createResponse.getUuid()));
 
 		assertNotNull(getResponse);
@@ -398,7 +399,7 @@ public class MeetingIT extends IntegrationWithOrganisationServiceTest {
 	public void testNotAcceptableException() {
 
 		try {
-			videoMeetings.meetingsUuidDelete(UUID.fromString("7cc82183-0d47-439a-a00c-38f7a5a01fc5"));
+			videoMeetings.v2MeetingsUuidDelete(UUID.fromString("7cc82183-0d47-439a-a00c-38f7a5a01fc5"));
 			fail();
 		}
 		catch(ApiException e) {

--- a/medcom-video-api-test/src/test/java/dk/medcom/video/api/test/SchedulingInfoIT.java
+++ b/medcom-video-api-test/src/test/java/dk/medcom/video/api/test/SchedulingInfoIT.java
@@ -12,7 +12,9 @@ import org.json.JSONObject;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.api.VideoMeetingsApi;
+import org.openapitools.client.api.VideoMeetingsV2Api;
 import org.openapitools.client.api.VideoSchedulingInformationApi;
+import org.openapitools.client.api.VideoSchedulingInformationV2Api;
 import org.openapitools.client.model.*;
 import org.junit.jupiter.api.Test;
 
@@ -300,10 +302,10 @@ public class SchedulingInfoIT extends IntegrationWithOrganisationServiceTest {
 				.setBasePath(String.format("http://%s:%s/api", videoApi.getHost(), videoApiPort))
 				.setOffsetDateTimeFormat(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss X"));
 
-		var videoMeetingApi = new VideoMeetingsApi(apiClient);
-		var schedulingInfoApi = new VideoSchedulingInformationApi(apiClient);
+		var videoMeetingApi = new VideoMeetingsV2Api(apiClient);
+		var schedulingInfoApi = new VideoSchedulingInformationV2Api(apiClient);
 
-		var schedulingInfo = schedulingInfoApi.schedulingInfoReserveGet(null,null,null,null,null,null,null,null,null);
+		var schedulingInfo = schedulingInfoApi.v2SchedulingInfoReserveGet(null,null,null,null,null,null,null,null,null);
 		assertNotNull(schedulingInfo);
 		var reservationId = schedulingInfo.getReservationId();
 
@@ -314,10 +316,10 @@ public class SchedulingInfoIT extends IntegrationWithOrganisationServiceTest {
 		createMeeting.setSubject("This is a subject!");
 		createMeeting.setSchedulingInfoReservationId(schedulingInfo.getReservationId());
 
-		var result = videoMeetingApi.meetingsPost(createMeeting);
+		var result = videoMeetingApi.v2MeetingsPost(createMeeting);
 		assertNotNull(result);
 
-		schedulingInfo = schedulingInfoApi.schedulingInfoUuidGet(result.getUuid());
+		schedulingInfo = schedulingInfoApi.v2SchedulingInfoUuidGet(result.getUuid());
 		assertNotNull(schedulingInfo);
 		assertEquals(reservationId, schedulingInfo.getReservationId());
 	}


### PR DESCRIPTION
# VDX RFC 

## Issue:
The following endpoint allow multiple query parameters:

`/v2/meetings?q={searchTerm}&offset={offset}&limit={limit}&from{from_date}&to{to_date}&type={type}...`

At the moment it is not possible to declare multiple query parameters since only one of these is eventually used.

depending of which of the query parameters is declared one of the methods below is invoked.
```
List<MeetingModel> getMeetingsV2(OffsetDateTime fromStartTime, OffsetDateTime toStartTime);
List<MeetingModel> getMeetingsBySubjectV2(String subject);
List<MeetingModel> getMeetingsByOrganizedByV2(String organizedBy);
List<MeetingModel> getMeetingsByUriWithDomainV2(String uriWithDomain);
List<MeetingModel> searchMeetingsV2(String search, OffsetDateTime fromStartTime, OffsetDateTime toStartTime);
List<MeetingModel> getMeetingsByLabelV2(String label);
```

## Proposal:
The methods presented above may be refactored into this:

`List<MeetingModel> fetch(V3MeetingQuery query);`


The query includes all the parameters which is deconstructed by the service and finally distributed into every repository required to serve the request. You would not need a specialized method for every combination.


This allow the developer to do something like this:

```
@RestController
public class MeetingController implements VideoMeetingsV3Api {

    private final MeetingServiceV3 meetingService;

    public MeetingController(MeetingServiceV3 meetingService) {
        this.meetingService = meetingService;
    }

    @Override
    public ResponseEntity<List<Meeting>> v3MeetingsGet(OffsetDateTime fromStartTime, OffsetDateTime toStartTime, String type) {
        V3MeetingQuery query = meetingService.query()
                .type(type)
                .from(fromStartTime)
                .to(toStartTime)
                .offset(0)
                .limit(10);

        return meetingService.fetch(query);
    }
}
```

## Further notice
If you watch closely, the `V3MeetingQuery` includes a `type` parameter. The suggested API will eventually return a list of meetings. If this is a `SimpleMeeting` or a `DetailedMeeting`. The type paramenter is used to filter on these.

Either this parameter originates from the token/context or it is given as a query parameter as below:

```
curl /v3/meetings
[{type: SimpleMeeting, ...},
{type: DetailedMeeting, ...}]
```

```
curl /v3/meetings?type=DetailedMeeting
[{ type: DetailedMeeting, ...},
{type: DetailedMeeting, ...}]
```

```
curl /v3/meetings?type=SimpleMeeting
[{type: SimpleMeeting, ...},
{type: SimpleMeeting, ...}]
```
